### PR TITLE
added g:VimuxUseExistingPaneWithIndex configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 doc/tags
+tags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# CHANGELOG
+
+## 2013-10-26
+* added config `g:VimuxUseExistingPaneWithIndex` to use a defined existing pane.

--- a/doc/vimux.txt
+++ b/doc/vimux.txt
@@ -8,16 +8,7 @@ CONTENTS                                                        *vimux-contents*
 
     1. About............................ |VimuxAbout|
     2. Usage ........................... |VimuxUsage|
-      2.1 .............................. |VimuxPromptCommand|
-      2.2 .............................. |VimuxRunLastCommand|
-      2.3 .............................. |VimuxInspectRunner|
-      2.4 .............................. |VimuxCloseRunner|
-      2.5 .............................. |VimuxClosePanes|
-      2.6 .............................. |VimuxInterruptRunner|
-      2.7 .............................. |VimuxClearRunnerHistory|
     3. Misc ............................ |VimuxMisc|
-      3.1 Example Keybinding............ |VimuxExampleKeybinding|
-      3.2 Tslime Replacement............ |VimuxTslimeReplacement|
     4. Configuration ................... |VimuxConfiguration|
 
 
@@ -121,7 +112,27 @@ Prompt for a command and run it in a small horizontal split bellow the current
 pane.
 >
  " Prompt for a command to run map
- <Leader>vp :VimuxPromptCommand<CR>
+ map <Leader>vp :VimuxPromptCommand<CR>
+<
+
+------------------------------------------------------------------------------
+                                                       *VimuxPromptForPaneIndex*
+VimuxPromptForPaneIndex~
+
+Prompt for the pane index in which commands shall be sent.
+>
+ " Prompt for a command to run map
+ map <Leader>vi :VimuxPromptForPaneIndex<CR>
+<
+
+------------------------------------------------------------------------------
+                                                       *VimuxDisplayPaneIndexes*
+VimuxDisplayPaneIndexes~
+
+Ask tmux to show the pane indexes.
+>
+ " Prompt for a command to run map
+ map <Leader>vd :VimuxDisplayPaneIndexes<CR>
 <
 
 ------------------------------------------------------------------------------

--- a/doc/vimux.txt
+++ b/doc/vimux.txt
@@ -278,8 +278,20 @@ Use exising pane (not used by vim) if found instead of running split-window.
 Default: 0
 
 ------------------------------------------------------------------------------
+                                           *VimuxConfiguration_use_existing_pane*
+2.4 g:VimuxUseExistingPaneWithIndex
+
+Uses already exising pane (identified by pane index) in the current active
+tmux session. Use `tmux display-panes` to display pane indexes.
+
+  let VimuxUseExistingPaneWithIndex = 1
+
+Default: 0
+
+
+------------------------------------------------------------------------------
                                              *VimuxConfiguration_reset_sequence*
-2.4 g:VimuxResetSequence~
+2.5 g:VimuxResetSequence~
 
 The keys sent to the runner pane before running a command. By default it sends
 `q` to make sure the pane is not in scroll-mode and `C-u` to clear the line.
@@ -290,7 +302,7 @@ Default: "q C-u"
 
 ------------------------------------------------------------------------------
                                                              *VimuxPromptString*
-2.5 g:VimuxPromptString~
+2.6 g:VimuxPromptString~
 
 The string presented in the vim command line when Vimux is invoked. Be sure
 to put a space at the end of the string to allow for distinction between

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -63,6 +63,7 @@ function! VimuxSendKeys(keys)
 endfunction
 
 function! VimuxPromptForPaneIndex()
+  call VimuxDisplayPaneIndexes()
   let g:VimuxRunnerPaneIndex = input("Pane Id? ")
 endfunction
 

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -3,6 +3,7 @@ if exists("g:loaded_vimux") || &cp
 endif
 let g:loaded_vimux = 1
 
+" Commands
 command VimuxRunLastCommand :call VimuxRunLastCommand()
 command VimuxCloseRunner :call VimuxCloseRunner()
 command VimuxInspectRunner :call VimuxInspectRunner()
@@ -12,6 +13,10 @@ command VimuxInterruptRunner :call VimuxInterruptRunner()
 command VimuxPromptCommand :call VimuxPromptCommand()
 command VimuxClearRunnerHistory :call VimuxClearRunnerHistory()
 
+" Defaults
+let g:VimuxUseExistingPaneWithIndex = 0
+
+" Functions
 function! VimuxRunLastCommand()
   if exists("g:VimuxRunnerPaneIndex")
     call VimuxRunCommand(g:VimuxLastCommand)
@@ -58,9 +63,12 @@ function! VimuxOpenPane()
   let orientation = _VimuxOption("g:VimuxOrientation", "v")
   let nearestIndex = _VimuxNearestPaneIndex()
 
-  if _VimuxOption("g:VimuxUseNearestPane", 1) == 1 && nearestIndex != -1
+  if _VimuxOption("g:VimuxUseExistingPaneWithIndex", 0) != 0
+    let g:VimuxRunnerPaneIndex = g:VimuxUseExistingPaneWithIndex
+  elseif _VimuxOption("g:VimuxUseNearestPane", 1) == 1 && nearestIndex != -1
     let g:VimuxRunnerPaneIndex = nearestIndex
   else
+    echo 'Using defined pane index'
     call system("tmux split-window -p ".height." -".orientation)
     let g:VimuxRunnerPaneIndex = _VimuxTmuxPaneIndex()
     call system("tmux last-pane")

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -14,7 +14,9 @@ command VimuxPromptCommand :call VimuxPromptCommand()
 command VimuxClearRunnerHistory :call VimuxClearRunnerHistory()
 
 " Defaults
-let g:VimuxUseExistingPaneWithIndex = 0
+if !exists("g:VimuxUseExistingPaneWithIndex")
+  let g:VimuxUseExistingPaneWithIndex = 0
+end
 
 " Functions
 function! VimuxRunLastCommand()

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -11,7 +11,9 @@ command VimuxScrollUpInspect :call VimuxScrollUpInspect()
 command VimuxScrollDownInspect :call VimuxScrollDownInspect()
 command VimuxInterruptRunner :call VimuxInterruptRunner()
 command VimuxPromptCommand :call VimuxPromptCommand()
+command VimuxPromptForPaneIndex :call VimuxPromptForPaneIndex()
 command VimuxClearRunnerHistory :call VimuxClearRunnerHistory()
+command VimuxDisplayPaneIndexes :call VimuxDisplayPaneIndexes()
 
 " Defaults
 if !exists("g:VimuxUseExistingPaneWithIndex")
@@ -58,6 +60,14 @@ function! VimuxSendKeys(keys)
   else
     echo "No vimux runner pane. Create one with VimuxOpenPane"
   endif
+endfunction
+
+function! VimuxPromptForPaneIndex()
+  let g:VimuxUseExistingPaneWithIndex = input("Pane Id? ")
+endfunction
+
+function! VimuxDisplayPaneIndexes()
+  call system("tmux display-panes")
 endfunction
 
 function! VimuxOpenPane()

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -63,7 +63,7 @@ function! VimuxSendKeys(keys)
 endfunction
 
 function! VimuxPromptForPaneIndex()
-  let g:VimuxUseExistingPaneWithIndex = input("Pane Id? ")
+  let g:VimuxRunnerPaneIndex = input("Pane Id? ")
 endfunction
 
 function! VimuxDisplayPaneIndexes()


### PR DESCRIPTION
I use vimux in MacVim and want to run my rspec tests always in the first pane of my tmux session. This options enables me to do so.

To enable that setting only in MacVim and disable it for the terminal I added the following to my .vimrc.

```
if has("gui_running")
  let g:VimuxUseExistingPaneWithIndex = 1
end
```
