### PR TITLE
Tmux buffers for sending text

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -53,7 +53,12 @@ function! VimuxRunCommand(command, ...)
 endfunction
 
 function! VimuxSendText(text)
-  call VimuxSendKeys('"'.escape(a:text, '"$').'"')
+  if exists("g:VimuxRunnerIndex")
+    call system("tmux load-buffer -", a:text)
+    call system("tmux paste-buffer -t " . g:VimuxRunnerIndex)
+  else
+    echo "No vimux runner pane/window. Create one with VimuxOpenRunner"
+  end
 endfunction
 
 function! VimuxSendKeys(keys)


### PR DESCRIPTION
This pull request fixes two issues:

1. Sending arbitrary long texts is now possible (see also issue #44). Using `tmux send-keys` resulted in a tmux crash if too much data was pasted from vim to tmux as the command was simply too long to be interpreted.
2. Shell interpolation is prevented. Instead the text is pasted precisely as is. An issue I encountered before was that I was required to escape any sequence containing a $ sign before sending it using `VimuxSendText`.
