### PR TITLE
VimuxRunCommandInDir: run in subshell

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -20,7 +20,7 @@ function! VimuxRunCommandInDir(command, useFile)
     if a:useFile ==# 1
         let l:file = shellescape(expand('%:t'), 1)
     endif
-    call VimuxRunCommand("cd ".shellescape(expand('%:p:h'), 1)." && ".a:command." ".l:file." && cd - > /dev/null")
+    call VimuxRunCommand("(cd ".shellescape(expand('%:p:h'), 1)." && ".a:command." ".l:file.")")
 endfunction
 
 function! VimuxRunLastCommand()


### PR DESCRIPTION
Fixes a problem where the directory is not restored if the command exits
with a non-zero code.