### PR TITLE
Add new option to expand the string given at VimuxPromptCommand.

### DIFF
--- a/doc/vimux.txt
+++ b/doc/vimux.txt
@@ -362,5 +362,21 @@ redefine this if you're using something like tmate.
 
 Default: "tmux"
 
+------------------------------------------------------------------------------
+                                                             *VimuxPromptString*
+2.8 g:VimuxExpandCommand~
+
+Should the command given at the prompt via VimuxPromptCommand be expanded
+using expand(). 1 to expand the string.
+
+Unfortunately expand() only expands % (etc.) if the string starts with that
+character. So the command is split at spaces and then rejoined after
+expansion. With this simple approach things like "%:h/test.xml" are not
+possible.
+
+  let g:VimuxPromptString = 1
+
+Default: 0
+
 ==============================================================================
 vim:tw=78:ts=2:sw=2:expandtab:ft=help:norl:

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -142,6 +142,9 @@ endfunction
 function! VimuxPromptCommand(...)
   let command = a:0 == 1 ? a:1 : ""
   let l:command = input(_VimuxOption("g:VimuxPromptString", "Command? "), command)
+  if _VimuxOption("g:VimuxExpandCommand", 0) == 1
+    let l:command = join(map(split(l:command, ' '), 'expand(v:val)'), ' ')
+  endif
   call VimuxRunCommand(l:command)
 endfunction
 


### PR DESCRIPTION
Unfortunately this is only a very simple approach. The expand()-function
in VimL is not very helpful. So the string is split at spaces, expanded and then rejoined. This functionality can be set via a vimux-option.

This might be a start to implement feature request #63.
