### PR TITLE
escape '$' before sending to tmux

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -53,7 +53,7 @@ function! VimuxRunCommand(command, ...)
 endfunction
 
 function! VimuxSendText(text)
-  call VimuxSendKeys('"'.escape(a:text, '"').'"')
+  call VimuxSendKeys('"'.escape(a:text, '"$').'"')
 endfunction
 
 function! VimuxSendKeys(keys)


### PR DESCRIPTION
When sending commands to bash containing dollar sign - the dollar sign disappears somehow. It is probably cut by bash/sh but I don't know exactly why.

Escaping with this patch '$' just works for me - but I don't why :-1: 