### PR TITLE
Check tmux binary availability at startup.

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -2,7 +2,7 @@
 
 Easily interact with tmux from vim.
 
-![vimux](https://www.braintreepayments.com/assets/images/blog/vimux3.png)
+![vimux](https://www.braintreepayments.com/blog/content/images/blog/vimux3.png)
 
 What inspired me to write vimux was [tslime.vim](https://github.com/kikijump/tslime.vim), a plugin that lets you send input to tmux. While tslime.vim works well, I felt it wasn't optimized for my primary use case which was having a smaller tmux pane that I would use to run tests or play with a REPL.
 

--- a/doc/vimux.txt
+++ b/doc/vimux.txt
@@ -306,7 +306,7 @@ Default: "v"
                                                 *VimuxConfiguration_use_nearest*
 2.3 g:VimuxUseNearest
 
-Use exising pane or window (not used by vim) if found instead of running
+Use existing pane or window (not used by vim) if found instead of running
 split-window.
 
   let VimuxUseNearest = 1

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -3,12 +3,20 @@ if exists("g:loaded_vimux") || &cp
 endif
 let g:loaded_vimux = 1
 
-if !exists("g:tmuxCmd")
-  let g:tmuxCmd = "tmux"
-endif
+function! _VimuxOption(option, default)
+  if exists(a:option)
+    return eval(a:option)
+  else
+    return a:default
+  endif
+endfunction
 
-if !executable(g:tmuxCmd)
-  echohl ErrorMsg | echomsg "Failed to find executable ".g:tmuxCmd | echohl None
+function! _VimuxTmuxCmd()
+  return _VimuxOption("g:VimuxTmuxCommand", "tmux")
+endfunction
+
+if !executable(_VimuxTmuxCmd())
+  echohl ErrorMsg | echomsg "Failed to find executable "._VimuxTmuxCmd() | echohl None
   finish
 endif
 
@@ -155,8 +163,7 @@ function! VimuxPromptCommand(...)
 endfunction
 
 function! _VimuxTmux(arguments)
-  let l:command = _VimuxOption("g:VimuxTmuxCommand", g:tmuxCmd)
-  return system(l:command." ".a:arguments)
+  return system(_VimuxTmuxCmd()." ".a:arguments)
 endfunction
 
 function! _VimuxTmuxSession()
@@ -193,14 +200,6 @@ endfunction
 
 function! _VimuxRunnerType()
   return _VimuxOption("g:VimuxRunnerType", "pane")
-endfunction
-
-function! _VimuxOption(option, default)
-  if exists(a:option)
-    return eval(a:option)
-  else
-    return a:default
-  endif
 endfunction
 
 function! _VimuxTmuxProperty(property)

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -62,7 +62,7 @@ function! VimuxRunCommand(command, ...)
 endfunction
 
 function! VimuxSendText(text)
-  call VimuxSendKeys('"'.escape(a:text, '\"$').'"')
+  call VimuxSendKeys('"'.escape(a:text, '\"$`').'"')
 endfunction
 
 function! VimuxSendKeys(keys)

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -3,6 +3,15 @@ if exists("g:loaded_vimux") || &cp
 endif
 let g:loaded_vimux = 1
 
+if !exists("g:tmuxCmd")
+  let g:tmuxCmd = "tmux"
+endif
+
+if !executable(g:tmuxCmd)
+  echohl ErrorMsg | echomsg "Failed to find executable ".g:tmuxCmd | echohl None
+  finish
+endif
+
 command -nargs=* VimuxRunCommand :call VimuxRunCommand(<args>)
 command VimuxRunLastCommand :call VimuxRunLastCommand()
 command VimuxCloseRunner :call VimuxCloseRunner()
@@ -146,7 +155,7 @@ function! VimuxPromptCommand(...)
 endfunction
 
 function! _VimuxTmux(arguments)
-  let l:command = _VimuxOption("g:VimuxTmuxCommand", "tmux")
+  let l:command = _VimuxOption("g:VimuxTmuxCommand", g:tmuxCmd)
   return system(l:command." ".a:arguments)
 endfunction
 


### PR DESCRIPTION
Updated the plugin to:
- let override the location of tmux executable.
- check tmux executable availability.

I noticed that you get a lot of issues opened stating that vimux doesn't work at all, i.e. any attempt to send text to a tmux pane is basically a noop, rendring the plugin not working/usable. I came across several dev env setups where tmux is not on the PATH and/or have alias for tmux. This contributes to this class of problems. While proposed patch doesn't solve all of those, it at least address this one particular env setup approach and will explicitly warn the user.