### PR TITLE
Added VimuxSetRunner to allow defining any panel as runner

### DIFF
--- a/doc/vimux.txt
+++ b/doc/vimux.txt
@@ -16,6 +16,7 @@ CONTENTS                                                        *vimux-contents*
       2.6 .............................. |VimuxClearRunnerHistory|
       2.7 .............................. |VimuxZoomRunner|
       2.8 .............................. |VimuxRunCommandInDir|
+      2.9 .............................. |VimuxSetRunner|
     3. Misc ............................ |VimuxMisc|
       3.1 Example Keybinding............ |VimuxExampleKeybinding|
       3.2 Tslime Replacement............ |VimuxTslimeReplacement|
@@ -69,6 +70,7 @@ Furthermore there are several handy commands all starting with 'Vimux':
   - |VimuxCloseRunner|
   - |VimuxInspectRunner|
   - |VimuxInterruptRunner|
+  - |VimuxSetRunner|
   - |VimuxPromptCommand|
   - |VimuxClearRunnerHistory|
   - |VimuxZoomRunner|
@@ -211,7 +213,15 @@ inFile: If 1 the filename will be appended to the command
  " Push the repository of the currently opened file
  nnoremap <leader>gp :call VimuxRunCommandInDir("git push", 0)<CR>
 <
+------------------------------------------------------------------------------
+                                                               *VimuxSetRunner*
+VimuxSetRunner~
 
+Define which pane to use as Runner.
+>
+ " Set pane with index 3 as runner
+ :call VimuxSetRunner(3)
+<
 ==============================================================================
 MISC (3)                                                             *VimuxMisc*
 
@@ -240,6 +250,9 @@ Full Keybind Example~
 
  " Zoom the runner pane (use <bind-key> z to restore runner pane)
  map <Leader>vz :call VimuxZoomRunner()<CR>
+
+ " prompts for new runner index
+ map <leader>vs :VimuxSetRunner(input('Runner index: '))<CR>
 >
 
 ------------------------------------------------------------------------------

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -14,6 +14,7 @@ command VimuxInterruptRunner :call VimuxInterruptRunner()
 command -nargs=? VimuxPromptCommand :call VimuxPromptCommand(<args>)
 command VimuxClearRunnerHistory :call VimuxClearRunnerHistory()
 command VimuxTogglePane :call VimuxTogglePane()
+command -nargs=? VimuxSetRunner :call VimuxSetRunner(<args>)
 
 function! VimuxRunCommandInDir(command, useFile)
     let l:file = ""
@@ -143,6 +144,12 @@ function! VimuxPromptCommand(...)
   let command = a:0 == 1 ? a:1 : ""
   let l:command = input(_VimuxOption("g:VimuxPromptString", "Command? "), command)
   call VimuxRunCommand(l:command)
+endfunction
+
+function! VimuxSetRunner(...)
+  if exists("a:1")
+    let g:VimuxRunnerIndex = a:1
+  endif
 endfunction
 
 function! _VimuxTmux(arguments)


### PR DESCRIPTION
Hi @benmills,

I think Vimux is pretty stable feature wise, however I was missing being able to define a specific pane as runner. I've made this change a few months ago and I've been using it in my fork since then.

The reasons why I think this feature is useful:
- Every time VIM closes or crash, you can't reuse the same pane as runner.
- Sometimes it is useful to alternate runner panes.
- When changing Tmux layouts, the runner index may change as well.

Feel free to decline this PR or suggest changes.
