### PR TITLE
Allow InteractivePane.

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -45,10 +45,17 @@ function! VimuxRunCommand(command, ...)
   let g:VimuxLastCommand = a:command
 
   call VimuxSendKeys(resetSequence)
-  call VimuxSendText(a:command)
 
-  if l:autoreturn == 1
-    call VimuxSendKeys("Enter")
+  let command = a:command
+  let g:VimuxInteractivePane = get( g:, 'VimuxInteractivePane', 0)
+  if g:VimuxInteractivePane
+      call _VimuxTmux("last-"._VimuxRunnerType())
+	  let command = command . " && tmux last-pane"
+  endif
+  call VimuxSendText(command)
+
+  if l:autoreturn == 1 
+	call VimuxSendKeys("Enter")
   endif
 endfunction
 


### PR DESCRIPTION
This is useful when we want to be interactive with the command that sends to the runner, by settting g:VimuxInteractivePane = 1, it will switch to the runner pane and wait until the command is finished then return back to vim.